### PR TITLE
Speed up serialization and deserializer.

### DIFF
--- a/EEUniverse.Library.Tests/Program.cs
+++ b/EEUniverse.Library.Tests/Program.cs
@@ -13,34 +13,6 @@ namespace EEUniverseLibrary.Tests
     {
         public static void Main(string[] args)
         {
-			var msg = new Message
-			(
-				ConnectionScope.Lobby,
-				MessageType.ChatOld,
-				"str",
-				12345,
-				-12345,
-				123456.0d,
-				true,
-				false,
-				false,
-				new byte[] { 1, 2, 3 },
-				new MessageObject()
-					.Add("a", "str")
-					.Add("b", 12345)
-					.Add("c", -12345)
-					.Add("d", 123456.0d)
-					.Add("e", true)
-					.Add("f", false)
-					.Add("g", new byte[] { 1, 2, 3 })
-			);
-
-			var bytes = Serializer.Serialize(msg);
-
-			var d1 = Serializer.Deserialize(bytes);
-			var d2 = Serializer.Deserialize(new System.ReadOnlySpan<byte>(bytes));
-
-			System.Console.WriteLine("done");
         }
     }
 }

--- a/EEUniverse.Library.Tests/Program.cs
+++ b/EEUniverse.Library.Tests/Program.cs
@@ -5,13 +5,42 @@
 
 // For now it's being manually tested...
 
+using EEUniverse.Library;
+
 namespace EEUniverseLibrary.Tests
 {
     public class Program
     {
         public static void Main(string[] args)
         {
+			var msg = new Message
+			(
+				ConnectionScope.Lobby,
+				MessageType.ChatOld,
+				"str",
+				12345,
+				-12345,
+				123456.0d,
+				true,
+				false,
+				false,
+				new byte[] { 1, 2, 3 },
+				new MessageObject()
+					.Add("a", "str")
+					.Add("b", 12345)
+					.Add("c", -12345)
+					.Add("d", 123456.0d)
+					.Add("e", true)
+					.Add("f", false)
+					.Add("g", new byte[] { 1, 2, 3 })
+			);
 
+			var bytes = Serializer.Serialize(msg);
+
+			var d1 = Serializer.Deserialize(bytes);
+			var d2 = Serializer.Deserialize(new System.ReadOnlySpan<byte>(bytes));
+
+			System.Console.WriteLine("done");
         }
     }
 }

--- a/EEUniverse.Library/.editorconfig
+++ b/EEUniverse.Library/.editorconfig
@@ -1,0 +1,95 @@
+# Rules in this file were initially inferred by Visual Studio IntelliCode from the C:\Users\SirJosh3917\Documents\GitHub\Library\EEUniverse.Library\ codebase based on best match to current usage at 10/14/2019
+# You can modify the rules from these initially generated values to suit your own policies
+# You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+[*.cs]
+
+#Core editorconfig formatting - indentation
+
+#use soft tabs (spaces) for indentation
+indent_style = space
+
+#Formatting - indentation options
+
+#csharp_indent_case_contents_when_block
+csharp_indent_case_contents_when_block = true
+#indent switch labels
+csharp_indent_switch_labels = true
+
+#Formatting - new line options
+
+#place catch statements on a new line
+csharp_new_line_before_catch = true
+#require braces to be on a new line for types and methods (also known as "Allman" style)
+csharp_new_line_before_open_brace = types, methods
+
+#Formatting - organize using options
+
+#sort System.* using directives alphabetically, and place them before other usings
+dotnet_sort_system_directives_first = true
+
+#Formatting - spacing options
+
+#require NO space between a cast and the value
+csharp_space_after_cast = false
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_after_colon_in_inheritance_clause = true
+#require a space after a keyword in a control flow statement such as a for loop
+csharp_space_after_keywords_in_control_flow_statements = true
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_before_colon_in_inheritance_clause = true
+#remove space within empty argument list parentheses
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+#remove space between method call name and opening parenthesis
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+#do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
+csharp_space_between_method_call_parameter_list_parentheses = false
+#remove space within empty parameter list parentheses for a method declaration
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+#place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+#Formatting - wrapping options
+
+#leave code block on single line
+csharp_preserve_single_line_blocks = true
+#leave statements and member declarations on the same line
+csharp_preserve_single_line_statements = true
+
+#Style - expression bodied member options
+
+#prefer expression-bodied members for accessors
+csharp_style_expression_bodied_accessors = true:suggestion
+#prefer expression-bodied members for indexers
+csharp_style_expression_bodied_indexers = true:suggestion
+#prefer expression-bodied members for methods
+csharp_style_expression_bodied_methods = true:suggestion
+#prefer expression-bodied members for properties
+csharp_style_expression_bodied_properties = true:suggestion
+
+#Style - expression level options
+
+#prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+#Style - implicit and explicit types
+
+#prefer var is used to declare variables with built-in system types such as int
+csharp_style_var_for_built_in_types = true:suggestion
+#prefer var when the type is already mentioned on the right-hand side of a declaration expression
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+#Style - language keyword and framework type options
+
+#prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+#Style - qualification options
+
+#prefer events not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_event = false:suggestion
+#prefer fields not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_field = false:suggestion
+#prefer methods not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_method = false:suggestion
+#prefer properties not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_property = false:suggestion

--- a/EEUniverse.Library/Client.cs
+++ b/EEUniverse.Library/Client.cs
@@ -69,22 +69,22 @@ namespace EEUniverse.Library
         /// <param name="message">The message to send.</param>
         public async Task SendAsync(Message message) => await SendRawAsync(Serializer.Serialize(message));
 
-		/// <summary>
-		/// Sends an asynchronous message to the server.<br />Use with caution.
-		/// </summary>
-		/// <param name="bytes">The buffer containing the message to be sent.</param>
-		public async Task SendRawAsync(ArraySegment<byte> bytes) => await _socket.SendAsync(bytes, WebSocketMessageType.Binary, true, CancellationToken.None);
+        /// <summary>
+        /// Sends an asynchronous message to the server.<br />Use with caution.
+        /// </summary>
+        /// <param name="bytes">The buffer containing the message to be sent.</param>
+        public async Task SendRawAsync(ArraySegment<byte> bytes) => await _socket.SendAsync(bytes, WebSocketMessageType.Binary, true, CancellationToken.None);
 
-		/// <summary>
-		/// Sends an asynchronous message to the server.<br />Use with caution.
-		/// </summary>
-		/// <param name="bytes">The buffer containing the message to be sent.</param>
-		public ValueTask SendRawAsync(ReadOnlyMemory<byte> bytes) => _socket.SendAsync(bytes, WebSocketMessageType.Binary, true, CancellationToken.None);
+        /// <summary>
+        /// Sends an asynchronous message to the server.<br />Use with caution.
+        /// </summary>
+        /// <param name="bytes">The buffer containing the message to be sent.</param>
+        public ValueTask SendRawAsync(ReadOnlyMemory<byte> bytes) => _socket.SendAsync(bytes, WebSocketMessageType.Binary, true, CancellationToken.None);
 
-		/// <summary>
-		/// Creates a connection with the lobby.
-		/// </summary>
-		public Connection CreateLobbyConnection() => new Connection(this, ConnectionScope.Lobby);
+        /// <summary>
+        /// Creates a connection with the lobby.
+        /// </summary>
+        public Connection CreateLobbyConnection() => new Connection(this, ConnectionScope.Lobby);
 
         /// <summary>
         /// Creates a connection with the specified world.

--- a/EEUniverse.Library/Client.cs
+++ b/EEUniverse.Library/Client.cs
@@ -56,6 +56,12 @@ namespace EEUniverse.Library
         }
 
         /// <summary>
+        /// Sends an asynchronous message to the server.<br />Use with caution.
+        /// </summary>
+        /// <param name="buffer">The buffer containing the message to be sent.</param>
+        public void SendRaw(ReadOnlyMemory<byte> buffer) => SendRawAsync(buffer).GetAwaiter().GetResult();
+
+        /// <summary>
         /// Sends an asynchronous message to the server.
         /// </summary>
         /// <param name="scope">The scope of the message.</param>

--- a/EEUniverse.Library/Client.cs
+++ b/EEUniverse.Library/Client.cs
@@ -69,16 +69,22 @@ namespace EEUniverse.Library
         /// <param name="message">The message to send.</param>
         public async Task SendAsync(Message message) => await SendRawAsync(Serializer.Serialize(message));
 
-        /// <summary>
-        /// Sends an asynchronous message to the server.<br />Use with caution.
-        /// </summary>
-        /// <param name="bytes">The buffer containing the message to be sent.</param>
-        public async Task SendRawAsync(ArraySegment<byte> bytes) => await _socket.SendAsync(bytes, WebSocketMessageType.Binary, true, CancellationToken.None);
+		/// <summary>
+		/// Sends an asynchronous message to the server.<br />Use with caution.
+		/// </summary>
+		/// <param name="bytes">The buffer containing the message to be sent.</param>
+		public async Task SendRawAsync(ArraySegment<byte> bytes) => await _socket.SendAsync(bytes, WebSocketMessageType.Binary, true, CancellationToken.None);
 
-        /// <summary>
-        /// Creates a connection with the lobby.
-        /// </summary>
-        public Connection CreateLobbyConnection() => new Connection(this, ConnectionScope.Lobby);
+		/// <summary>
+		/// Sends an asynchronous message to the server.<br />Use with caution.
+		/// </summary>
+		/// <param name="bytes">The buffer containing the message to be sent.</param>
+		public ValueTask SendRawAsync(ReadOnlyMemory<byte> bytes) => _socket.SendAsync(bytes, WebSocketMessageType.Binary, true, CancellationToken.None);
+
+		/// <summary>
+		/// Creates a connection with the lobby.
+		/// </summary>
+		public Connection CreateLobbyConnection() => new Connection(this, ConnectionScope.Lobby);
 
         /// <summary>
         /// Creates a connection with the specified world.
@@ -104,8 +110,7 @@ namespace EEUniverse.Library
                     if (!result.EndOfMessage)
                         continue;
 
-                    var bytes = new Span<byte>(buffer)[..count].ToArray();
-                    var message = Serializer.Deserialize(bytes);
+                    var message = Serializer.Deserialize(new Span<byte>(buffer)[..count]);
                     OnMessage?.Invoke(this, message);
                     count = 0;
                 }

--- a/EEUniverse.Library/Connection.cs
+++ b/EEUniverse.Library/Connection.cs
@@ -59,6 +59,12 @@ namespace EEUniverse.Library
         public void SendRaw(ArraySegment<byte> buffer) => _ = SendRawAsync(buffer);
 
         /// <summary>
+        /// Sends an asynchronous message to the server.<br />Use with caution.
+        /// </summary>
+        /// <param name="buffer">The buffer containing the message to be sent.</param>
+        public void SendRaw(ReadOnlyMemory<byte> buffer) => SendRawAsync(buffer).GetAwaiter().GetResult();
+
+        /// <summary>
         /// Sends an asynchronous message to the server.
         /// </summary>
         /// <param name="type">The type of the message.</param>

--- a/EEUniverse.Library/Connection.cs
+++ b/EEUniverse.Library/Connection.cs
@@ -76,5 +76,11 @@ namespace EEUniverse.Library
         /// </summary>
         /// <param name="buffer">The buffer containing the message to be sent.</param>
         public async Task SendRawAsync(ArraySegment<byte> buffer) => await _client.SendRawAsync(buffer);
+
+        /// <summary>
+        /// Sends an asynchronous message to the server.<br />Use with caution.
+        /// </summary>
+        /// <param name="bytes">The buffer containing the message to be sent.</param>
+        public ValueTask SendRawAsync(ReadOnlyMemory<byte> bytes) => _client.SendRawAsync(bytes);
     }
 }

--- a/EEUniverse.Library/EEUniverse.Library.csproj
+++ b/EEUniverse.Library/EEUniverse.Library.csproj
@@ -29,4 +29,8 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
+  </ItemGroup>
+
 </Project>

--- a/EEUniverse.Library/Message.cs
+++ b/EEUniverse.Library/Message.cs
@@ -8,7 +8,7 @@ namespace EEUniverse.Library
     /// <summary>
     /// Represents an Everybody Edits Universe™ message.
     /// </summary>
-    public class Message : IEnumerable
+    public class Message : IEnumerable<object>
     {
         /// <summary>
         /// Represents the scope this message was received in.
@@ -50,9 +50,7 @@ namespace EEUniverse.Library
             _data = new List<object>(data);
         }
 
-        /// <summary>
-        /// Returns an IEnumerator for the data.
-        /// </summary>
+        IEnumerator<object> IEnumerable<object>.GetEnumerator() => _data.GetEnumerator();
         public IEnumerator GetEnumerator() => _data.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/EEUniverse.Library/MessageReader.cs
+++ b/EEUniverse.Library/MessageReader.cs
@@ -5,95 +5,95 @@ using System.Text;
 namespace EEUniverse.Library
 {
     /// <summary>
-	/// A speedy message reader.
-	/// </summary>
-	public ref struct MessageReader
-	{
-		private const MethodImplOptions Inlining = MethodImplOptions.AggressiveInlining;
+    /// A speedy message reader.
+    /// </summary>
+    public ref struct MessageReader
+    {
+        private const MethodImplOptions Inlining = MethodImplOptions.AggressiveInlining;
 
-		private ReadOnlySpan<byte> _data;
-		private int _i;
+        private ReadOnlySpan<byte> _data;
+        private int _i;
 
-		public MessageReader(ReadOnlySpan<byte> data)
-		{
-			_data = data;
-			_i = 0;
-		}
-
-		[MethodImpl(Inlining)]
-		public void BackUp() => _i--;
+        public MessageReader(ReadOnlySpan<byte> data)
+        {
+            _data = data;
+            _i = 0;
+        }
 
         [MethodImpl(Inlining)]
-		public bool IsDataLeft() => _i < _data.Length;
+        public void BackUp() => _i--;
+
+        [MethodImpl(Inlining)]
+        public bool IsDataLeft() => _i < _data.Length;
 
         // for now, it is completely safe to cast the byte to the enum
         // in the future, this WILL cause a problem -
         // the ReadInt is preferred in the future.
         // as for now, this is a non issue.
 
-		[MethodImpl(Inlining)]
-		public ConnectionScope ReadConnectionScope()
+        [MethodImpl(Inlining)]
+        public ConnectionScope ReadConnectionScope()
             => (ConnectionScope)_data[_i++];
 
-		[MethodImpl(Inlining)]
-		public MessageType ReadMessageType()
+        [MethodImpl(Inlining)]
+        public MessageType ReadMessageType()
             => (MessageType)_data[_i++];
 
-		[MethodImpl(Inlining)]
-		public string ReadString()
+        [MethodImpl(Inlining)]
+        public string ReadString()
             => Encoding.UTF8.GetString(ReadBytes());
 
-		[MethodImpl(Inlining)]
-		public ReadOnlySpan<byte> ReadBytes()
+        [MethodImpl(Inlining)]
+        public ReadOnlySpan<byte> ReadBytes()
             => ReadBytes(ReadInt());
 
-		[MethodImpl(Inlining)]
-		public double ReadDouble()
-			=> BitConverter.ToDouble(ReadBytes(8));
+        [MethodImpl(Inlining)]
+        public double ReadDouble()
+            => BitConverter.ToDouble(ReadBytes(8));
 
-		[MethodImpl]
-		public byte ReadByte()
-			=> _data[_i++];
+        [MethodImpl]
+        public byte ReadByte()
+            => _data[_i++];
 
-		[MethodImpl(Inlining)]
+        [MethodImpl(Inlining)]
         public ReadOnlySpan<byte> ReadBytes(int length)
         {
-			var bytes = _data.Slice(_i, length);
+            var bytes = _data.Slice(_i, length);
 
-			_i += length;
+            _i += length;
 
-			return bytes;
-		}
+            return bytes;
+        }
 
-		[MethodImpl(Inlining)]
-		public int ReadInt()
-		{
-			// basically copied and pasted from https://source.dot.net/#System.Private.CoreLib/shared/System/IO/BinaryReader.cs,587
+        [MethodImpl(Inlining)]
+        public int ReadInt()
+        {
+            // basically copied and pasted from https://source.dot.net/#System.Private.CoreLib/shared/System/IO/BinaryReader.cs,587
 
-			var count = 0;
-			var shift = 0;
-			byte b;
+            var count = 0;
+            var shift = 0;
+            byte b;
 
-			do
-			{
-				if (shift == 5 * 7)
-				{
-					ThrowBadFormat();
-				}
+            do
+            {
+                if (shift == 5 * 7)
+                {
+                    ThrowBadFormat();
+                }
 
-				b = _data[_i++];
+                b = _data[_i++];
 
-				count |= (b & 0b0111_1111) << shift;
-				shift += 7;
-			}
-			while ((b & 0b1000_0000) != 0b0000_0000);
+                count |= (b & 0b0111_1111) << shift;
+                shift += 7;
+            }
+            while ((b & 0b1000_0000) != 0b0000_0000);
 
-			return count;
-		}
+            return count;
+        }
 
-		// see: https://reubenbond.github.io/posts/dotnet-perf-tuning
-		[MethodImpl(MethodImplOptions.NoInlining)]
-		private static void ThrowBadFormat()
-			=> throw new FormatException("Too many bytes in what should have been a 7 bit encoded Int32.");
-	}
+        // see: https://reubenbond.github.io/posts/dotnet-perf-tuning
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowBadFormat()
+            => throw new FormatException("Too many bytes in what should have been a 7 bit encoded Int32.");
+    }
 }

--- a/EEUniverse.Library/MessageReader.cs
+++ b/EEUniverse.Library/MessageReader.cs
@@ -20,9 +20,11 @@ namespace EEUniverse.Library
 			_i = 0;
 		}
 
+		[MethodImpl(Inlining)]
+		public void BackUp() => _i--;
+
         [MethodImpl(Inlining)]
-		public bool IsDataLeft()
-            => _i < _data.Length;
+		public bool IsDataLeft() => _i < _data.Length;
 
 		[MethodImpl(Inlining)]
 		public ConnectionScope ReadConnectionScope()
@@ -63,7 +65,6 @@ namespace EEUniverse.Library
 		{
 			// basically copied and pasted from https://source.dot.net/#System.Private.CoreLib/shared/System/IO/BinaryReader.cs,587
 
-			var i = 0;
 			var count = 0;
 			var shift = 0;
 			byte b;
@@ -75,14 +76,13 @@ namespace EEUniverse.Library
 					ThrowBadFormat();
 				}
 
-				b = _data[i++];
+				b = _data[_i++];
 
 				count |= (b & 0b0111_1111) << shift;
 				shift += 7;
 			}
 			while ((b & 0b1000_0000) != 0b0000_0000);
 
-			_data = _data.Slice(i);
 			return count;
 		}
 

--- a/EEUniverse.Library/MessageReader.cs
+++ b/EEUniverse.Library/MessageReader.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace EEUniverse.Library
+{
+    /// <summary>
+	/// A speedy message reader.
+	/// </summary>
+	public ref struct MessageReader
+	{
+		private const MethodImplOptions Inlining = MethodImplOptions.AggressiveInlining;
+
+		private ReadOnlySpan<byte> _data;
+		private int _i;
+
+		public MessageReader(ReadOnlySpan<byte> data)
+		{
+			_data = data;
+			_i = 0;
+		}
+
+        [MethodImpl(Inlining)]
+		public bool IsDataLeft()
+            => _i < _data.Length;
+
+		[MethodImpl(Inlining)]
+		public ConnectionScope ReadConnectionScope()
+            => (ConnectionScope)_data[_i++];
+
+		[MethodImpl(Inlining)]
+		public MessageType ReadMessageType()
+            => (MessageType)Read7BitEncodedInt();
+
+		[MethodImpl(Inlining)]
+		public string ReadString()
+            => Encoding.UTF8.GetString(ReadBytes());
+
+		[MethodImpl(Inlining)]
+		public ReadOnlySpan<byte> ReadBytes()
+            => ReadBytes(Read7BitEncodedInt());
+
+		[MethodImpl(Inlining)]
+		public double ReadDouble()
+			=> BitConverter.ToDouble(ReadBytes(8));
+
+		[MethodImpl]
+		public byte ReadByte()
+			=> _data[_i++];
+
+		[MethodImpl(Inlining)]
+        public ReadOnlySpan<byte> ReadBytes(int length)
+        {
+			var bytes = _data.Slice(_i, length);
+
+			_i += length;
+
+			return bytes;
+		}
+
+		[MethodImpl(Inlining)]
+		public int Read7BitEncodedInt()
+		{
+			// basically copied and pasted from https://source.dot.net/#System.Private.CoreLib/shared/System/IO/BinaryReader.cs,587
+
+			var i = 0;
+			var count = 0;
+			var shift = 0;
+			byte b;
+
+			do
+			{
+				if (shift == 5 * 7)
+				{
+					ThrowBadFormat();
+				}
+
+				b = _data[i++];
+
+				count |= (b & 0b0111_1111) << shift;
+				shift += 7;
+			}
+			while ((b & 0b1000_0000) != 0b0000_0000);
+
+			_data = _data.Slice(i);
+			return count;
+		}
+
+		// see: https://reubenbond.github.io/posts/dotnet-perf-tuning
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static void ThrowBadFormat()
+			=> throw new FormatException("Too many bytes in what should have been a 7 bit encoded Int32.");
+	}
+}

--- a/EEUniverse.Library/MessageReader.cs
+++ b/EEUniverse.Library/MessageReader.cs
@@ -26,13 +26,18 @@ namespace EEUniverse.Library
         [MethodImpl(Inlining)]
 		public bool IsDataLeft() => _i < _data.Length;
 
+        // for now, it is completely safe to cast the byte to the enum
+        // in the future, this WILL cause a problem -
+        // the ReadInt is preferred in the future.
+        // as for now, this is a non issue.
+
 		[MethodImpl(Inlining)]
 		public ConnectionScope ReadConnectionScope()
             => (ConnectionScope)_data[_i++];
 
 		[MethodImpl(Inlining)]
 		public MessageType ReadMessageType()
-            => (MessageType)Read7BitEncodedInt();
+            => (MessageType)_data[_i++];
 
 		[MethodImpl(Inlining)]
 		public string ReadString()
@@ -40,7 +45,7 @@ namespace EEUniverse.Library
 
 		[MethodImpl(Inlining)]
 		public ReadOnlySpan<byte> ReadBytes()
-            => ReadBytes(Read7BitEncodedInt());
+            => ReadBytes(ReadInt());
 
 		[MethodImpl(Inlining)]
 		public double ReadDouble()
@@ -61,7 +66,7 @@ namespace EEUniverse.Library
 		}
 
 		[MethodImpl(Inlining)]
-		public int Read7BitEncodedInt()
+		public int ReadInt()
 		{
 			// basically copied and pasted from https://source.dot.net/#System.Private.CoreLib/shared/System/IO/BinaryReader.cs,587
 

--- a/EEUniverse.Library/MessageWriter.cs
+++ b/EEUniverse.Library/MessageWriter.cs
@@ -5,86 +5,86 @@ using System.Text;
 
 namespace EEUniverse.Library
 {
-	public ref struct MessageWriter
-	{
-		private const MethodImplOptions Inlining = MethodImplOptions.AggressiveInlining;
+    public ref struct MessageWriter
+    {
+        private const MethodImplOptions Inlining = MethodImplOptions.AggressiveInlining;
 
-		private readonly Span<byte> _target;
-		private int _i;
+        private readonly Span<byte> _target;
+        private int _i;
 
-		public MessageWriter(Span<byte> target)
-		{
-			_target = target;
-			_i = 0;
-		}
+        public MessageWriter(Span<byte> target)
+        {
+            _target = target;
+            _i = 0;
+        }
 
-		[MethodImpl(Inlining)]
-		public void Write(byte value)
+        [MethodImpl(Inlining)]
+        public void Write(byte value)
             => _target[_i++] = value;
 
         // as of present day, it is currently entirely safe to cast these.
         // in the future, a 7 bit encoded int will be needed if there are more
 
-		[MethodImpl(Inlining)]
-		public void Write(ConnectionScope value)
-			=> Write((byte)value);
+        [MethodImpl(Inlining)]
+        public void Write(ConnectionScope value)
+            => Write((byte)value);
 
-		[MethodImpl(Inlining)]
-		public void Write(MessageType value)
-			=> Write((byte)value);
+        [MethodImpl(Inlining)]
+        public void Write(MessageType value)
+            => Write((byte)value);
 
-		[MethodImpl(Inlining)]
-		public void Write(double value)
-		{
-			// BitConverter doesn't have a method to do this
-			// thus, following ToDouble and working backwards https://source.dot.net/#System.Private.CoreLib/shared/System/BitConverter.cs,354
-			// this is here
-
-			var position = _target.Slice(_i);
-
-			Unsafe.WriteUnaligned<double>(ref MemoryMarshal.GetReference(position), value);
-
-			_i += sizeof(double);
-		}
-
-		[MethodImpl(Inlining)]
-		public void Write(string value)
-		{
-			Write(value.Length);
-			Encoding.UTF8.GetBytes(value, _target.Slice(_i));
-			_i += value.Length;
-		}
-
-		[MethodImpl(Inlining)]
-		public void Write(byte[] value)
-			=> Write(new ReadOnlySpan<byte>(value));
-
-		[MethodImpl(Inlining)]
-		public void Write(ReadOnlySpan<byte> value)
-		{
-			Write(value.Length);
-			WriteBytes(value);
-		}
-
-		[MethodImpl(Inlining)]
-		public void WriteBytes(ReadOnlySpan<byte> value)
+        [MethodImpl(Inlining)]
+        public void Write(double value)
         {
-			value.CopyTo(_target.Slice(_i));
-			_i += value.Length;
-		}
+            // BitConverter doesn't have a method to do this
+            // thus, following ToDouble and working backwards https://source.dot.net/#System.Private.CoreLib/shared/System/BitConverter.cs,354
+            // this is here
 
-		[MethodImpl(Inlining)]
+            var position = _target.Slice(_i);
+
+            Unsafe.WriteUnaligned<double>(ref MemoryMarshal.GetReference(position), value);
+
+            _i += sizeof(double);
+        }
+
+        [MethodImpl(Inlining)]
+        public void Write(string value)
+        {
+            Write(value.Length);
+            Encoding.UTF8.GetBytes(value, _target.Slice(_i));
+            _i += value.Length;
+        }
+
+        [MethodImpl(Inlining)]
+        public void Write(byte[] value)
+            => Write(new ReadOnlySpan<byte>(value));
+
+        [MethodImpl(Inlining)]
+        public void Write(ReadOnlySpan<byte> value)
+        {
+            Write(value.Length);
+            WriteBytes(value);
+        }
+
+        [MethodImpl(Inlining)]
+        public void WriteBytes(ReadOnlySpan<byte> value)
+        {
+            value.CopyTo(_target.Slice(_i));
+            _i += value.Length;
+        }
+
+        [MethodImpl(Inlining)]
         public void Write(int value)
-		{
-			// nearly copied from https://source.dot.net/#System.Private.CoreLib/shared/System/IO/BinaryWriter.cs,456
+        {
+            // nearly copied from https://source.dot.net/#System.Private.CoreLib/shared/System/IO/BinaryWriter.cs,456
 
-			while (value >= 0b1_000_0000)
-			{
-				Write((byte)(value | 0b1_000_0000));
-				value >>= 7;
-			}
+            while (value >= 0b1_000_0000)
+            {
+                Write((byte)(value | 0b1_000_0000));
+                value >>= 7;
+            }
 
-			Write((byte)value);
-		}
-	}
+            Write((byte)value);
+        }
+    }
 }

--- a/EEUniverse.Library/MessageWriter.cs
+++ b/EEUniverse.Library/MessageWriter.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace EEUniverse.Library
+{
+	public ref struct MessageWriter
+	{
+		private const MethodImplOptions Inlining = MethodImplOptions.AggressiveInlining;
+
+		private readonly Span<byte> _target;
+		private int _i;
+
+		public MessageWriter(Span<byte> target)
+		{
+			_target = target;
+			_i = 0;
+		}
+
+		[MethodImpl(Inlining)]
+		public void Write(byte value)
+            => _target[_i++] = value;
+
+        // as of present day, it is currently entirely safe to cast these.
+        // in the future, a 7 bit encoded int will be needed if there are more
+
+		[MethodImpl(Inlining)]
+		public void Write(ConnectionScope value)
+			=> Write((byte)value);
+
+		[MethodImpl(Inlining)]
+		public void Write(MessageType value)
+			=> Write((byte)value);
+
+		[MethodImpl(Inlining)]
+		public void Write(double value)
+		{
+			// BitConverter doesn't have a method to do this
+			// thus, following ToDouble and working backwards https://source.dot.net/#System.Private.CoreLib/shared/System/BitConverter.cs,354
+			// this is here
+
+			var position = _target.Slice(_i);
+
+			Unsafe.WriteUnaligned<double>(ref MemoryMarshal.GetReference(position), value);
+
+			_i += sizeof(double);
+		}
+
+		[MethodImpl(Inlining)]
+		public void Write(string value)
+		{
+			Write(value.Length);
+			Encoding.UTF8.GetBytes(value, _target.Slice(_i));
+			_i += value.Length;
+		}
+
+		[MethodImpl(Inlining)]
+		public void Write(byte[] value)
+			=> Write(new ReadOnlySpan<byte>(value));
+
+		[MethodImpl(Inlining)]
+		public void Write(ReadOnlySpan<byte> value)
+		{
+			Write(value.Length);
+			WriteBytes(value);
+		}
+
+		[MethodImpl(Inlining)]
+		public void WriteBytes(ReadOnlySpan<byte> value)
+        {
+			value.CopyTo(_target.Slice(_i));
+			_i += value.Length;
+		}
+
+		[MethodImpl(Inlining)]
+        public void Write(int value)
+		{
+			// nearly copied from https://source.dot.net/#System.Private.CoreLib/shared/System/IO/BinaryWriter.cs,456
+
+			while (value >= 0b1_000_0000)
+			{
+				Write((byte)(value | 0b1_000_0000));
+				value >>= 7;
+			}
+
+			Write((byte)value);
+		}
+	}
+}

--- a/EEUniverse.Library/Serializer.cs
+++ b/EEUniverse.Library/Serializer.cs
@@ -21,13 +21,13 @@ namespace EEUniverse.Library
         private const byte _patternObjectEnd = 8;
 
         /// <summary>
-		/// Calculates the exact size of a message, in bytes.
-		/// </summary>
+        /// Calculates the exact size of a message, in bytes.
+        /// </summary>
         public static int EstimateSize(Message message)
         {
-			// currently, a connectionscope & message type can't be above 1 byte when 7 bit encoded.
-			// this optimization is safe, currently.
-			int size = 2
+            // currently, a connectionscope & message type can't be above 1 byte when 7 bit encoded.
+            // this optimization is safe, currently.
+            int size = 2
 
             // we add the message count because every item in the message requires a byte for the pattern type
             // that way we don't have to do size++ in the loop
@@ -35,239 +35,239 @@ namespace EEUniverse.Library
 
             for (var i = 0; i < message.Count; i++)
             {
-				var data = message[i];
+                var data = message[i];
 
-				switch (data)
-				{
-					case int val: size += GetVarIntSize(val < 0 ? -val : val); break;
-					case string val: size += GetVarIntSize(val.Length) + Encoding.UTF8.GetByteCount(val); break;
-					case byte[] val: size += GetVarIntSize(val.Length) + val.Length; break;
+                switch (data)
+                {
+                    case int val: size += GetVarIntSize(val < 0 ? -val : val); break;
+                    case string val: size += GetVarIntSize(val.Length) + Encoding.UTF8.GetByteCount(val); break;
+                    case byte[] val: size += GetVarIntSize(val.Length) + val.Length; break;
 
-					case double _: size += sizeof(double); break;
+                    case double _: size += sizeof(double); break;
 
-					case bool _: break;
+                    case bool _: break;
 
-					case IDictionary<string, object> dict:
+                    case IDictionary<string, object> dict:
                     {
-						// there's a pattern byte for each value
-						size += dict.Count
+                        // there's a pattern byte for each value
+                        size += dict.Count
 
                         // there's a byte to end the pattern
                             + 1;
 
                         foreach(var kvp in dict)
                         {
-							// write string
-							size += GetVarIntSize(kvp.Key.Length) + Encoding.UTF8.GetByteCount(kvp.Key);
+                            // write string
+                            size += GetVarIntSize(kvp.Key.Length) + Encoding.UTF8.GetByteCount(kvp.Key);
 
                             // TODO: i literally just copied and pasted this
                             // this is literally awful D:
 
                             switch(kvp.Value)
-							{
-								case int val: size += GetVarIntSize(val < 0 ? -val : val); break;
-								case string val: size += GetVarIntSize(val.Length) + Encoding.UTF8.GetByteCount(val); break;
-								case byte[] val: size += GetVarIntSize(val.Length) + val.Length; break;
+                            {
+                                case int val: size += GetVarIntSize(val < 0 ? -val : val); break;
+                                case string val: size += GetVarIntSize(val.Length) + Encoding.UTF8.GetByteCount(val); break;
+                                case byte[] val: size += GetVarIntSize(val.Length) + val.Length; break;
 
-								case double _: size += sizeof(double); break;
+                                case double _: size += sizeof(double); break;
 
-								case bool _: break;
-							}
-						}
-					}
-					break;
-				}
-			}
+                                case bool _: break;
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
 
-			return size;
-		}
+            return size;
+        }
 
         private static int GetVarIntSize(int value)
-	    {
-			// nearly copied from https://source.dot.net/#System.Private.CoreLib/shared/System/IO/BinaryWriter.cs,456
-
-			// Write out an int 7 bits at a time.  The high bit of the byte,
-			// when on, tells reader to continue reading more bytes.
-			uint v = (uint)value;   // support negative numbers
-			int size = 1;
-			while (v >= 0x80)
-			{
-				size++;
-				v >>= 7;
-			}
-
-			return size;
-		}
-
-		/// <summary>
-		/// Convert a message into a stream of bytes.<br />Use with extreme caution.
-		/// </summary>
-		public static Memory<byte> Serialize(Message message)
         {
-			var target = new Memory<byte>(new byte[EstimateSize(message)]);
-			var writer = new MessageWriter(target.Span);
+            // nearly copied from https://source.dot.net/#System.Private.CoreLib/shared/System/IO/BinaryWriter.cs,456
 
-			writer.Write(message.Scope);
-			writer.Write(message.Type);
+            // Write out an int 7 bits at a time.  The high bit of the byte,
+            // when on, tells reader to continue reading more bytes.
+            uint v = (uint)value;   // support negative numbers
+            int size = 1;
+            while (v >= 0x80)
+            {
+                size++;
+                v >>= 7;
+            }
+
+            return size;
+        }
+
+        /// <summary>
+        /// Convert a message into a stream of bytes.<br />Use with extreme caution.
+        /// </summary>
+        public static Memory<byte> Serialize(Message message)
+        {
+            var target = new Memory<byte>(new byte[EstimateSize(message)]);
+            var writer = new MessageWriter(target.Span);
+
+            writer.Write(message.Scope);
+            writer.Write(message.Type);
 
             for (var i = 0; i < message.Count; i++)
             {
-				var data = message[i];
+                var data = message[i];
 
-				switch (data)
-				{
-					case bool @bool: writer.Write(@bool ? _patternBooleanTrue : _patternBooleanFalse); break;
+                switch (data)
+                {
+                    case bool @bool: writer.Write(@bool ? _patternBooleanTrue : _patternBooleanFalse); break;
 
-					case int @int:
-					{
-						writer.Write(@int < 0 ? _patternIntNeg : _patternIntPos);
-						writer.Write(@int < 0 ? -(@int + 1) : @int);
-					}
-					break;
+                    case int @int:
+                    {
+                        writer.Write(@int < 0 ? _patternIntNeg : _patternIntPos);
+                        writer.Write(@int < 0 ? -(@int + 1) : @int);
+                    }
+                    break;
 
-					case double @double:
-					{
-						writer.Write(_patternDouble);
-						writer.Write(@double);
-					}
-					break;
+                    case double @double:
+                    {
+                        writer.Write(_patternDouble);
+                        writer.Write(@double);
+                    }
+                    break;
 
-					case string @string:
-					{
-						writer.Write(_patternString);
-						writer.Write(@string);
-					}
-					break;
+                    case string @string:
+                    {
+                        writer.Write(_patternString);
+                        writer.Write(@string);
+                    }
+                    break;
 
-					case byte[] bytes:
-					{
-						writer.Write(_patternBytes);
-						writer.Write(bytes);
-					}
-					break;
+                    case byte[] bytes:
+                    {
+                        writer.Write(_patternBytes);
+                        writer.Write(bytes);
+                    }
+                    break;
 
-					case IDictionary<string, object> dict:
-					{
-						writer.Write(_patternObject);
+                    case IDictionary<string, object> dict:
+                    {
+                        writer.Write(_patternObject);
 
                         foreach(var (key, value) in dict)
-						{
-							if (key.Length == _patternObjectEnd) // Until they fix, which will be a breaking change...
-							{
-								throw new InvalidDataException("The specified key in MessageObject is invalid; it must be lower or greater than 8 characters in length.");
-							}
+                        {
+                            if (key.Length == _patternObjectEnd) // Until they fix, which will be a breaking change...
+                            {
+                                throw new InvalidDataException("The specified key in MessageObject is invalid; it must be lower or greater than 8 characters in length.");
+                            }
 
-							writer.Write(key);
+                            writer.Write(key);
                             
                             // this blatant copying and pasting actually hurts my soul
                             switch(value)
-							{
-								case bool @bool: writer.Write(@bool ? _patternBooleanTrue : _patternBooleanFalse); break;
+                            {
+                                case bool @bool: writer.Write(@bool ? _patternBooleanTrue : _patternBooleanFalse); break;
 
-								case int @int:
-								{
-									writer.Write(@int < 0 ? _patternIntNeg : _patternIntPos);
-									writer.Write(@int < 0 ? -(@int + 1) : @int);
-								}
-								break;
+                                case int @int:
+                                {
+                                    writer.Write(@int < 0 ? _patternIntNeg : _patternIntPos);
+                                    writer.Write(@int < 0 ? -(@int + 1) : @int);
+                                }
+                                break;
 
-								case double @double:
-								{
-									writer.Write(_patternDouble);
-									writer.Write(@double);
-								}
-								break;
+                                case double @double:
+                                {
+                                    writer.Write(_patternDouble);
+                                    writer.Write(@double);
+                                }
+                                break;
 
-								case string @string:
-								{
-									writer.Write(_patternString);
-									writer.Write(@string);
-								}
-								break;
+                                case string @string:
+                                {
+                                    writer.Write(_patternString);
+                                    writer.Write(@string);
+                                }
+                                break;
 
-								case byte[] bytes:
-								{
-									writer.Write(_patternBytes);
-									writer.Write(bytes);
-								}
-								break;
-							}
-						}
+                                case byte[] bytes:
+                                {
+                                    writer.Write(_patternBytes);
+                                    writer.Write(bytes);
+                                }
+                                break;
+                            }
+                        }
 
-						writer.Write(_patternObjectEnd);
-					}
-					break;
-				}
-			}
+                        writer.Write(_patternObjectEnd);
+                    }
+                    break;
+                }
+            }
 
-			return target;
-		}
+            return target;
+        }
 
-		/// <summary>
-		/// Deserialize a stream of bytes into a message.<br />Use with extreme caution.
-		/// </summary>
-		public static Message Deserialize(ReadOnlySpan<byte> data)
+        /// <summary>
+        /// Deserialize a stream of bytes into a message.<br />Use with extreme caution.
+        /// </summary>
+        public static Message Deserialize(ReadOnlySpan<byte> data)
         {
-			var reader = new MessageReader(data);
+            var reader = new MessageReader(data);
 
-			var scope = reader.ReadConnectionScope();
-			var type = reader.ReadMessageType();
+            var scope = reader.ReadConnectionScope();
+            var type = reader.ReadMessageType();
 
-			var argData = new List<object>();
+            var argData = new List<object>();
 
-			while (reader.IsDataLeft())
-			{
-				var patternType = reader.ReadByte();
+            while (reader.IsDataLeft())
+            {
+                var patternType = reader.ReadByte();
 
-				object obj;
+                object obj;
 
-				switch (patternType)
-				{
-					case _patternString: obj = reader.ReadString(); break;
-					case _patternIntPos: obj = reader.ReadInt(); break;
-					case _patternIntNeg: obj = -reader.ReadInt(); break;
-					case _patternDouble: obj = reader.ReadDouble(); break;
-					case _patternBooleanTrue: obj = true; break;
-					case _patternBooleanFalse: obj = false; break;
-					case _patternBytes: obj = reader.ReadBytes().ToArray(); break;
-					case _patternObject:
+                switch (patternType)
+                {
+                    case _patternString: obj = reader.ReadString(); break;
+                    case _patternIntPos: obj = reader.ReadInt(); break;
+                    case _patternIntNeg: obj = -reader.ReadInt(); break;
+                    case _patternDouble: obj = reader.ReadDouble(); break;
+                    case _patternBooleanTrue: obj = true; break;
+                    case _patternBooleanFalse: obj = false; break;
+                    case _patternBytes: obj = reader.ReadBytes().ToArray(); break;
+                    case _patternObject:
                     {
-						var messageObject = new MessageObject();
+                        var messageObject = new MessageObject();
 
                         while (reader.ReadByte() != _patternObjectEnd)
                         {
-							reader.BackUp();
+                            reader.BackUp();
 
-							var key = reader.ReadString();
-							object value;
+                            var key = reader.ReadString();
+                            object value;
 
-							switch (reader.ReadByte())
+                            switch (reader.ReadByte())
                             {
-								case _patternString: value = reader.ReadString(); break;
-								case _patternIntPos: value = reader.ReadInt(); break;
-								case _patternIntNeg: value = -reader.ReadInt(); break;
-								case _patternDouble: value = reader.ReadDouble(); break;
-								case _patternBooleanTrue: value = true; break;
-								case _patternBooleanFalse: value = false; break;
-								case _patternBytes: value = reader.ReadBytes().ToArray(); break;
+                                case _patternString: value = reader.ReadString(); break;
+                                case _patternIntPos: value = reader.ReadInt(); break;
+                                case _patternIntNeg: value = -reader.ReadInt(); break;
+                                case _patternDouble: value = reader.ReadDouble(); break;
+                                case _patternBooleanTrue: value = true; break;
+                                case _patternBooleanFalse: value = false; break;
+                                case _patternBytes: value = reader.ReadBytes().ToArray(); break;
 
-								default: throw new InvalidDataException($"Invalid pattern type {patternType} in MessageObject.");
-							}
+                                default: throw new InvalidDataException($"Invalid pattern type {patternType} in MessageObject.");
+                            }
 
-							messageObject.Add(key, value);
-						}
+                            messageObject.Add(key, value);
+                        }
 
-						obj = messageObject;
-					}
-					break;
+                        obj = messageObject;
+                    }
+                    break;
 
-					default: throw new InvalidDataException($"Invalid pattern type {patternType}.");
-				}
+                    default: throw new InvalidDataException($"Invalid pattern type {patternType}.");
+                }
 
-				argData.Add(obj);
-			}
+                argData.Add(obj);
+            }
 
-			return new Message(scope, type, argData.ToArray());
-		}
+            return new Message(scope, type, argData.ToArray());
+        }
     }
 }

--- a/EEUniverse.Library/Serializer.cs
+++ b/EEUniverse.Library/Serializer.cs
@@ -147,15 +147,14 @@ namespace EEUniverse.Library
                     {
 						var messageObject = new MessageObject();
 
-                        while ((patternType = reader.ReadByte()) != _patternObjectEnd)
+                        while (reader.ReadByte() != _patternObjectEnd)
                         {
 							reader.BackUp();
 
 							var key = reader.ReadString();
 							object value;
 
-							patternType = reader.ReadByte();
-							switch (patternType)
+							switch (reader.ReadByte())
                             {
 								case _patternString: value = reader.ReadString(); break;
 								case _patternIntPos: value = reader.Read7BitEncodedInt(); break;

--- a/EEUniverse.Library/Serializer.cs
+++ b/EEUniverse.Library/Serializer.cs
@@ -69,56 +69,10 @@ namespace EEUniverse.Library
 								case double _: size += sizeof(double); break;
 
 								case bool _: break;
-
-								// actually don't know if we even need to handle byte & sbyte & ushort & short :v
-								// so they'll be placed at the bottom with the least chance of being hit
-
-								// if there are bugs, oh well :)
-								// none of this code below is tested :)
-
-								case byte @byte:
-								{
-									size += 2;
-
-									// 7 bit encoded int thing
-									if (@byte >= 0b1_000_0000)
-									{
-										size++;
-									}
-								}
-								break;
-
-								case sbyte val: size += GetVarIntSize(val); break;
-								case short val: size += GetVarIntSize(val); break;
-								case ushort val: size += GetVarIntSize(val); break;
-								case uint val: size += GetVarIntSize((int)val); break;
 							}
 						}
 					}
 					break;
-
-                    // actually don't know if we even need to handle byte & sbyte & ushort & short :v
-                    // so they'll be placed at the bottom with the least chance of being hit
-
-                    // if there are bugs, oh well :)
-                    // none of this code below is tested :)
-
-					case byte @byte:
-					{
-						size += 2;
-
-                        // 7 bit encoded int thing
-                        if (@byte >= 0b1_000_0000)
-                        {
-							size++;
-						}
-					}
-					break;
-
-					case sbyte val: size += GetVarIntSize(val); break;
-					case short val: size += GetVarIntSize(val); break;
-					case ushort val: size += GetVarIntSize(val); break;
-					case uint val: size += GetVarIntSize((int)val); break;
 				}
 			}
 

--- a/EEUniverse.Library/Serializer.cs
+++ b/EEUniverse.Library/Serializer.cs
@@ -309,7 +309,7 @@ namespace EEUniverse.Library
 
 			var argData = new List<object>();
 
-			do
+			while (reader.IsDataLeft())
 			{
 				var patternType = reader.ReadByte();
 
@@ -360,7 +360,6 @@ namespace EEUniverse.Library
 
 				argData.Add(obj);
 			}
-			while (reader.IsDataLeft());
 
 			return new Message(scope, type, argData.ToArray());
 		}

--- a/EEUniverse.Library/Serializer.cs
+++ b/EEUniverse.Library/Serializer.cs
@@ -20,6 +20,9 @@ namespace EEUniverse.Library
         private const byte _patternObject = 7;
         private const byte _patternObjectEnd = 8;
 
+        /// <summary>
+		/// Calculates the exact size of a message, in bytes.
+		/// </summary>
         public static int EstimateSize(Message message)
         {
 			// currently, a connectionscope & message type can't be above 1 byte when 7 bit encoded.
@@ -99,10 +102,10 @@ namespace EEUniverse.Library
 		/// <summary>
 		/// Convert a message into a stream of bytes.<br />Use with extreme caution.
 		/// </summary>
-		public static Span<byte> SerializeFast(Message message)
+		public static Memory<byte> Serialize(Message message)
         {
-			var target = new Span<byte>(new byte[EstimateSize(message)]);
-			var writer = new MessageWriter(target);
+			var target = new Memory<byte>(new byte[EstimateSize(message)]);
+			var writer = new MessageWriter(target.Span);
 
 			writer.Write(message.Scope);
 			writer.Write(message.Type);
@@ -200,103 +203,6 @@ namespace EEUniverse.Library
 			return target;
 		}
 
-        /// <summary>
-        /// Convert a message into a stream of bytes.<br />Use with caution.
-        /// </summary>
-        public static byte[] Serialize(Message message)
-        {
-            var memStream = new MemoryStream();
-            using var writer = new BitEncodedStreamWriter(memStream);
-            writer.Write7BitEncodedInt((byte)message.Scope);
-            writer.Write7BitEncodedInt((int)message.Type);
-
-            foreach (var data in message) {
-                switch (data) {
-                    case bool oBool: writer.Write(oBool ? _patternBooleanTrue : _patternBooleanFalse); break;
-
-                    case byte oByte:
-                    case sbyte oSByte:
-                    case short oShort:
-                    case int oInt: {
-                            var value = Convert.ToInt32(data);
-                            writer.Write(value < 0 ? _patternIntNeg : _patternIntPos);
-                            writer.Write7BitEncodedInt(value < 0 ? -(value + 1) : value);
-                        }
-                        break;
-
-                    case double oDouble: {
-                            writer.Write(_patternDouble);
-                            writer.Write(oDouble);
-                        }
-                        break;
-
-                    case string oString: {
-                            writer.Write(_patternString);
-                            writer.Write(oString);
-                        }
-                        break;
-
-                    case byte[] oBytes: {
-                            writer.Write(_patternBytes);
-                            writer.Write7BitEncodedInt(oBytes.Length);
-                            writer.Write(oBytes);
-                        }
-                        break;
-
-                    case IDictionary<string, object> oDict: {
-                            writer.Write(_patternObject);
-                            foreach (var kvp in oDict) {
-                                if (kvp.Key.Length == 8) // Until they fix, which will be a breaking change...
-                                    throw new InvalidDataException("The specified key in MessageObject is invalid; it must be lower or greater than 8 characters in length.");
-
-                                writer.Write(kvp.Key);
-                                switch (kvp.Value) {
-                                    case bool oBool: writer.Write(oBool ? _patternBooleanTrue : _patternBooleanFalse); break;
-
-                                    case byte oByte:
-                                    case sbyte oSByte:
-                                    case short oShort:
-                                    case int oInt: {
-                                            var value = Convert.ToInt32(kvp.Value);
-                                            writer.Write(value < 0 ? _patternIntNeg : _patternIntPos);
-                                            writer.Write7BitEncodedInt(value < 0 ? -(value + 1) : value);
-                                        }
-                                        break;
-
-                                    case double oDouble: {
-                                            writer.Write(_patternDouble);
-                                            writer.Write(oDouble);
-                                        }
-                                        break;
-
-                                    case string oString: {
-                                            writer.Write(_patternString);
-                                            writer.Write(oString);
-                                        }
-                                        break;
-
-                                    case byte[] oBytes: {
-                                            writer.Write(_patternBytes);
-                                            writer.Write7BitEncodedInt(oBytes.Length);
-                                            writer.Write(oBytes);
-                                        }
-                                        break;
-
-                                    default: throw new NotSupportedException($"Data type {kvp.Value.GetType().Name} in MessageObject not supported.");
-                                }
-                            }
-
-                            writer.Write(_patternObjectEnd);
-                        }
-                        break;
-
-                    default: throw new NotSupportedException($"Data type {data.GetType().Name} is not supported.");
-                }
-            }
-
-            return memStream.ToArray();
-        }
-
 		/// <summary>
 		/// Deserialize a stream of bytes into a message.<br />Use with extreme caution.
 		/// </summary>
@@ -363,64 +269,5 @@ namespace EEUniverse.Library
 
 			return new Message(scope, type, argData.ToArray());
 		}
-
-        /// <summary>
-        /// Deserialize a stream of bytes into a message.<br />Use with caution.
-        /// </summary>
-        public static Message Deserialize(byte[] data)
-        {
-            using var stream = new BitEncodedStreamReader(new MemoryStream(data));
-            var scope = (ConnectionScope)stream.ReadByte();
-            var type = (MessageType)stream.Read7BitEncodedInt();
-
-            var argData = new List<object>();
-            while (stream.BaseStream.Position < data.Length) {
-                var patternType = stream.ReadByte();
-                switch (patternType) {
-                    case _patternString: argData.Add(stream.ReadString()); break;
-                    case _patternIntPos: argData.Add(stream.Read7BitEncodedInt()); break;
-                    case _patternIntNeg: argData.Add(-stream.Read7BitEncodedInt() - 1); break;
-                    case _patternDouble: argData.Add(BitConverter.ToDouble(stream.ReadBytes(8), 0)); break;
-                    case _patternBooleanFalse: argData.Add(false); break;
-                    case _patternBooleanTrue: argData.Add(true); break;
-                    case _patternBytes: {
-                            var length = stream.Read7BitEncodedInt();
-                            argData.Add(stream.ReadBytes(length));
-                        }
-                        break;
-
-                    case _patternObject: {
-                            var objectArgs = new MessageObject();
-                            while (stream.ReadByte() != _patternObjectEnd) {
-                                stream.BaseStream.Position--;
-
-                                var objectIndex = stream.ReadString();
-                                switch (stream.ReadByte()) {
-                                    case _patternString: objectArgs.Add(objectIndex, stream.ReadString()); break;
-                                    case _patternIntPos: objectArgs.Add(objectIndex, stream.Read7BitEncodedInt()); break;
-                                    case _patternIntNeg: objectArgs.Add(objectIndex, -stream.Read7BitEncodedInt() - 1); break;
-                                    case _patternDouble: objectArgs.Add(objectIndex, BitConverter.ToDouble(stream.ReadBytes(8), 0)); break;
-                                    case _patternBooleanFalse: objectArgs.Add(objectIndex, false); break;
-                                    case _patternBooleanTrue: objectArgs.Add(objectIndex, true); break;
-                                    case _patternBytes: {
-                                            var length = stream.Read7BitEncodedInt();
-                                            objectArgs.Add(objectIndex, stream.ReadBytes(length));
-                                        }
-                                        break;
-
-                                    default: throw new InvalidDataException($"Invalid pattern type {patternType} in MessageObject.");
-                                }
-                            }
-
-                            argData.Add(objectArgs);
-                        }
-                        break;
-
-                    default: throw new InvalidDataException($"Invalid pattern type {patternType}.");
-                }
-            }
-
-            return new Message(scope, type, argData.ToArray());
-        }
     }
 }


### PR DESCRIPTION
The current serializer/deserializer is a bit slow, this commit speeds things up.

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 8.1 (6.3.9600.0)
Unknown processor
Frequency=2924198 Hz, Resolution=341.9741 ns, Timer=TSC
.NET Core SDK=3.0.100
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT


```
|                       Method |        Mean |      Error |     StdDev |
|----------------------------- |------------:|-----------:|-----------:|
|    Complicated_Serialize_Old | 1,579.55 ns | 18.2802 ns | 17.0993 ns |
|   Complicated_Serialize_Fast | 1,083.86 ns |  9.4249 ns |  8.3550 ns |
|  Complicated_Deserialize_Old | 1,968.07 ns | 18.4542 ns | 15.4101 ns |
| Complicated_Deserialize_Fast | 1,340.28 ns | 12.7395 ns | 11.9165 ns |
|        Nothing_Serialize_Old |   154.25 ns |  2.0295 ns |  1.7991 ns |
|       Nothing_Serialize_Fast |    26.41 ns |  0.2338 ns |  0.2073 ns |
|      Nothing_Deserialize_Old |   145.48 ns |  1.7362 ns |  1.6240 ns |
|     Nothing_Deserialize_Fast |    72.66 ns |  0.9093 ns |  0.8505 ns |


Benchmark code: (notice: if you'd want to get this to work, you'd have to go to about the 8th/9th commit, somewhere around there, and get `BenchmarkDotNet`)

```cs
// Ideally these would be automated tests with a mocked server.
// Potential libraries to use:
//  - Specflow (https://github.com/techtalk/SpecFlow); To write human-readable acceptance tests.
//  - Moq (https://github.com/moq/moq4); To easily mock functions. (mainly to fake the client part, because connecting to the real Everybody Edits Universe™ servers is a bad idea...)

// For now it's being manually tested...

using BenchmarkDotNet.Attributes;
using EEUniverse.Library;
using System;

namespace EEUniverseLibrary.Tests
{
	public class Program
	{
		private Message _complicated = new Message
		(
			ConnectionScope.Lobby,
			MessageType.ChatOld,
			"str",
			12345,
			-12345,
			123456.0d,
			true,
			false,
			false,
			new byte[] { 1, 2, 3 },
			new MessageObject()
				.Add("a", "str")
				.Add("b", 12345)
				.Add("c", -12345)
				.Add("d", 123456.0d)
				.Add("e", true)
				.Add("f", false)
				.Add("g", new byte[] { 1, 2, 3 })
		);

		private Message _nothing = new Message(ConnectionScope.Lobby, MessageType.ChatOld);

		public Program()
		{
			_complicatedBytes = Serializer.Serialize(_complicated);
			_nothingBytes = Serializer.Serialize(_nothing);
		}

		private byte[] _complicatedBytes;
		private byte[] _nothingBytes;

		[Benchmark]
		public byte[] Complicated_Serialize_Old()
		{
			return Serializer.Serialize(_complicated);
		}

		[Benchmark]
		public Span<byte> Complicated_Serialize_Fast()
		{
			return Serializer.SerializeFast(_complicated);
		}

		[Benchmark]
		public Message Complicated_Deserialize_Old()
		{
			return Serializer.Deserialize(_complicatedBytes);
		}

		[Benchmark]
		public Message Complicated_Deserialize_Fast()
		{
			return Serializer.Deserialize(new ReadOnlySpan<byte>(_complicatedBytes));
		}

		[Benchmark]
		public byte[] Nothing_Serialize_Old()
		{
			return Serializer.Serialize(_nothing);
		}

		[Benchmark]
		public Span<byte> Nothing_Serialize_Fast()
		{
			return Serializer.SerializeFast(_nothing);
		}

		[Benchmark]
		public Message Nothing_Deserialize_Old()
		{
			return Serializer.Deserialize(_nothingBytes);
		}

		[Benchmark]
		public Message Nothing_Deserialize_Fast()
		{
			return Serializer.Deserialize(new ReadOnlySpan<byte>(_nothingBytes));
		}

		public static void Main(string[] args)
		{
			BenchmarkDotNet.Running.BenchmarkRunner.Run<Program>();
		}
	}
}
```