### PR TITLE
elide a lot of async crud

### DIFF
--- a/EEUniverse.Library/Client.cs
+++ b/EEUniverse.Library/Client.cs
@@ -61,19 +61,19 @@ namespace EEUniverse.Library
         /// <param name="scope">The scope of the message.</param>
         /// <param name="type">The type of the message.</param>
         /// <param name="data">An array of data to be sent.</param>
-        public async Task SendAsync(ConnectionScope scope, MessageType type, params object[] data) => await SendAsync(new Message(scope, type, data));
+        public Task SendAsync(ConnectionScope scope, MessageType type, params object[] data) => SendAsync(new Message(scope, type, data));
 
         /// <summary>
         /// Sends an asynchronous message to the server.
         /// </summary>
         /// <param name="message">The message to send.</param>
-        public async Task SendAsync(Message message) => await SendRawAsync(Serializer.Serialize(message));
+        public Task SendAsync(Message message) => SendRawAsync(Serializer.Serialize(message));
 
         /// <summary>
         /// Sends an asynchronous message to the server.<br />Use with caution.
         /// </summary>
         /// <param name="bytes">The buffer containing the message to be sent.</param>
-        public async Task SendRawAsync(ArraySegment<byte> bytes) => await _socket.SendAsync(bytes, WebSocketMessageType.Binary, true, CancellationToken.None);
+        public Task SendRawAsync(ArraySegment<byte> bytes) => _socket.SendAsync(bytes, WebSocketMessageType.Binary, true, CancellationToken.None);
 
         /// <summary>
         /// Creates a connection with the lobby.

--- a/EEUniverse.Library/Connection.cs
+++ b/EEUniverse.Library/Connection.cs
@@ -63,18 +63,18 @@ namespace EEUniverse.Library
         /// </summary>
         /// <param name="type">The type of the message.</param>
         /// <param name="data">An array of data to be sent.</param>
-        public async Task SendAsync(MessageType type, params object[] data) => await SendRawAsync(Serializer.Serialize(new Message(_scope, type, data)));
+        public Task SendAsync(MessageType type, params object[] data) => SendRawAsync(Serializer.Serialize(new Message(_scope, type, data)));
 
         /// <summary>
         /// Sends an asynchronous message to the server.
         /// </summary>
         /// <param name="message">The message to be sent.</param>
-        public async Task SendAsync(Message message) => await SendRawAsync(Serializer.Serialize(message));
+        public Task SendAsync(Message message) => SendRawAsync(Serializer.Serialize(message));
 
         /// <summary>
         /// Sends an asynchronous message to the server.<br />Use with caution.
         /// </summary>
         /// <param name="buffer">The buffer containing the message to be sent.</param>
-        public async Task SendRawAsync(ArraySegment<byte> buffer) => await _client.SendRawAsync(buffer);
+        public Task SendRawAsync(ArraySegment<byte> buffer) => _client.SendRawAsync(buffer);
     }
 }


### PR DESCRIPTION
there's a bunch of

```cs
public async Task DoAsync() => await SomethingAsync();
```

this is bad for numerous reasons, outlined in [this blog post](https://blog.stephencleary.com/2016/12/eliding-async-await.html):

- creation of an async state machine
- bloated file size, because of the async state machine

this simple PR aims to solve that.