### PR TITLE
add more synchronous overloads & fix the existing synchronous overloads

### DIFF
--- a/EEUniverse.Library/Client.cs
+++ b/EEUniverse.Library/Client.cs
@@ -47,6 +47,11 @@ namespace EEUniverse.Library
         /// <summary>
         /// Establishes a connection with the server and starts listening for messages.
         /// </summary>
+        public void Connect() => ConnectAsync().GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Establishes a connection with the server and starts listening for messages.
+        /// </summary>
         public async Task ConnectAsync()
         {
             await _socket.ConnectAsync(new Uri($"{MultiplayerHost}/?a={_token}"), CancellationToken.None);
@@ -54,6 +59,15 @@ namespace EEUniverse.Library
             _messageReceiverThread = new Thread(async () => await MessageReceiver());
             _messageReceiverThread.Start();
         }
+
+        /// <summary>
+        /// Sends a message to the server, synchronously.
+        /// </summary>
+        /// <param name="scope">The scope of the message.</param>
+        /// <param name="type">The type of the message.</param>
+        /// <param name="data">An array of data to be sent.</param>
+        public void Send(ConnectionScope scope, MessageType type, params object[] data)
+            => SendAsync(new Message(scope, type, data)).GetAwaiter().GetResult;
 
         /// <summary>
         /// Sends an asynchronous message to the server.
@@ -64,10 +78,23 @@ namespace EEUniverse.Library
         public async Task SendAsync(ConnectionScope scope, MessageType type, params object[] data) => await SendAsync(new Message(scope, type, data));
 
         /// <summary>
+        /// Sends a message to the server, synchronously.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        public void Send(Message message)
+            => SendAsync(message).GetAwaiter().GetResult;
+
+        /// <summary>
         /// Sends an asynchronous message to the server.
         /// </summary>
         /// <param name="message">The message to send.</param>
         public async Task SendAsync(Message message) => await SendRawAsync(Serializer.Serialize(message));
+
+        /// <summary>
+        /// Sends a message to the server, synchronously.<br />Use with caution.
+        /// </summary>
+        /// <param name="bytes">The buffer containing the message to be sent.</param>
+        public void SendRaw(ArraySegment<byte> bytes) => SendRawAsync(bytes).GetAwaiter().GetResult();
 
         /// <summary>
         /// Sends an asynchronous message to the server.<br />Use with caution.

--- a/EEUniverse.Library/Client.cs
+++ b/EEUniverse.Library/Client.cs
@@ -61,7 +61,7 @@ namespace EEUniverse.Library
         }
 
         /// <summary>
-        /// Sends a message to the server, synchronously.
+        /// Sends a message to the server.
         /// </summary>
         /// <param name="scope">The scope of the message.</param>
         /// <param name="type">The type of the message.</param>
@@ -70,7 +70,7 @@ namespace EEUniverse.Library
             => SendAsync(new Message(scope, type, data)).GetAwaiter().GetResult;
 
         /// <summary>
-        /// Sends an asynchronous message to the server.
+        /// Sends a message to the server as an asynchronous operation.
         /// </summary>
         /// <param name="scope">The scope of the message.</param>
         /// <param name="type">The type of the message.</param>
@@ -78,26 +78,26 @@ namespace EEUniverse.Library
         public async Task SendAsync(ConnectionScope scope, MessageType type, params object[] data) => await SendAsync(new Message(scope, type, data));
 
         /// <summary>
-        /// Sends a message to the server, synchronously.
+        /// Sends a message to the server.
         /// </summary>
         /// <param name="message">The message to send.</param>
         public void Send(Message message)
             => SendAsync(message).GetAwaiter().GetResult;
 
         /// <summary>
-        /// Sends an asynchronous message to the server.
+        /// Sends a message to the server as an asynchronous operation.
         /// </summary>
         /// <param name="message">The message to send.</param>
         public async Task SendAsync(Message message) => await SendRawAsync(Serializer.Serialize(message));
 
         /// <summary>
-        /// Sends a message to the server, synchronously.<br />Use with caution.
+        /// Sends a message to the server.<br />Use with caution.
         /// </summary>
         /// <param name="bytes">The buffer containing the message to be sent.</param>
         public void SendRaw(ArraySegment<byte> bytes) => SendRawAsync(bytes).GetAwaiter().GetResult();
 
         /// <summary>
-        /// Sends an asynchronous message to the server.<br />Use with caution.
+        /// Sends a message to the server as an asynchronous operation.<br />Use with caution.
         /// </summary>
         /// <param name="bytes">The buffer containing the message to be sent.</param>
         public async Task SendRawAsync(ArraySegment<byte> bytes) => await _socket.SendAsync(bytes, WebSocketMessageType.Binary, true, CancellationToken.None);

--- a/EEUniverse.Library/Connection.cs
+++ b/EEUniverse.Library/Connection.cs
@@ -44,19 +44,19 @@ namespace EEUniverse.Library
         /// </summary>
         /// <param name="type">The type of the message.</param>
         /// <param name="data">An array of data to be sent.</param>
-        public void Send(MessageType type, params object[] data) => _ = SendAsync(new Message(_scope, type, data));
+        public void Send(MessageType type, params object[] data) => SendAsync(new Message(_scope, type, data)).GetAwaiter().GetResult();
 
         /// <summary>
         /// Sends a message to the server.
         /// </summary>
         /// <param name="message">The message to be sent.</param>
-        public void Send(Message message) => _ = SendRawAsync(Serializer.Serialize(message));
+        public void Send(Message message) => SendRawAsync(Serializer.Serialize(message)).GetAwaiter().GetResult();
 
         /// <summary>
         /// Sends an asynchronous message to the server.<br />Use with caution.
         /// </summary>
         /// <param name="buffer">The buffer containing the message to be sent.</param>
-        public void SendRaw(ArraySegment<byte> buffer) => _ = SendRawAsync(buffer);
+        public void SendRaw(ArraySegment<byte> buffer) => SendRawAsync(buffer).GetAwaiter().GetResult();
 
         /// <summary>
         /// Sends an asynchronous message to the server.


### PR DESCRIPTION
doing
```cs
_ = SomethingAsync
```
just heaves the task onto the threadpool for god knows when to complete - i've made the synchornous methods blocking, as they should be. god forbid anyone use sync though, that's a horrifying idea. honestly, synchronous should probably be scrapped to an entirely different library that's opt-in.