### PR TITLE
Add `IClient` and `IConnection` counterparts, for better abstraction.

### DIFF
--- a/EEUniverse.Library/Connection.cs
+++ b/EEUniverse.Library/Connection.cs
@@ -3,14 +3,14 @@ using System.Threading.Tasks;
 
 namespace EEUniverse.Library
 {
-    public class Connection
+    public class Connection : IConnection
     {
         /// <summary>
         /// An event that raises when the client receives a message with the assigned scope.
         /// </summary>
         public event EventHandler<Message> OnMessage;
 
-        private readonly Client _client;
+        private readonly IClient _client;
         private readonly ConnectionScope _scope;
 
         /// <summary>
@@ -19,7 +19,7 @@ namespace EEUniverse.Library
         /// <param name="client">The underlying client of this connection.</param>
         /// <param name="scope">The scope of the connection.<br />This is what the connection listens to in the OnMessage EventHandler.</param>
         /// <param name="worldId">The world ID to connect to.<br />This should only be filled when creating a connection with the 'World' scope.</param>
-        public Connection(Client client, ConnectionScope scope, string worldId = "")
+        public Connection(IClient client, ConnectionScope scope, string worldId = "")
         {
             _client = client;
             _scope = scope;
@@ -35,46 +35,12 @@ namespace EEUniverse.Library
                 if (string.IsNullOrEmpty(worldId))
                     throw new ArgumentNullException($"{nameof(worldId)} should not be null or empty when the scope is world.");
 
-                Send(new Message(ConnectionScope.Lobby, 0, "world", worldId));
+                ((IConnection)this).Send(new Message(ConnectionScope.Lobby, 0, "world", worldId));
             }
         }
 
-        /// <summary>
-        /// Sends a message to the server.
-        /// </summary>
-        /// <param name="type">The type of the message.</param>
-        /// <param name="data">An array of data to be sent.</param>
-        public void Send(MessageType type, params object[] data) => SendAsync(new Message(_scope, type, data)).GetAwaiter().GetResult();
+        public Task SendAsync(MessageType type, params object[] data) => _client.SendAsync(_scope, type, data);
 
-        /// <summary>
-        /// Sends a message to the server.
-        /// </summary>
-        /// <param name="message">The message to be sent.</param>
-        public void Send(Message message) => SendRawAsync(Serializer.Serialize(message)).GetAwaiter().GetResult();
-
-        /// <summary>
-        /// Sends an asynchronous message to the server.<br />Use with caution.
-        /// </summary>
-        /// <param name="buffer">The buffer containing the message to be sent.</param>
-        public void SendRaw(ArraySegment<byte> buffer) => SendRawAsync(buffer).GetAwaiter().GetResult();
-
-        /// <summary>
-        /// Sends an asynchronous message to the server.
-        /// </summary>
-        /// <param name="type">The type of the message.</param>
-        /// <param name="data">An array of data to be sent.</param>
-        public Task SendAsync(MessageType type, params object[] data) => SendRawAsync(Serializer.Serialize(new Message(_scope, type, data)));
-
-        /// <summary>
-        /// Sends an asynchronous message to the server.
-        /// </summary>
-        /// <param name="message">The message to be sent.</param>
-        public Task SendAsync(Message message) => SendRawAsync(Serializer.Serialize(message));
-
-        /// <summary>
-        /// Sends an asynchronous message to the server.<br />Use with caution.
-        /// </summary>
-        /// <param name="buffer">The buffer containing the message to be sent.</param>
-        public Task SendRawAsync(ArraySegment<byte> buffer) => _client.SendRawAsync(buffer);
+        public Task SendAsync(Message message) => _client.SendAsync(message);
     }
 }

--- a/EEUniverse.Library/IClient.cs
+++ b/EEUniverse.Library/IClient.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace EEUniverse.Library
+{
+	/// <summary>
+	/// Provides a client for connecting to Everybody Edits Universe™
+	/// </summary>
+	public interface IClient : IAsyncDisposable
+    {
+        /// <summary>
+        /// An event that raises when the client receives a message.
+        /// </summary>
+        event EventHandler<Message> OnMessage;
+
+        /// <summary>
+        /// An event that raises when the connection to the server is lost.
+        /// </summary>
+        event EventHandler<CloseEventArgs> OnDisconnect;
+
+        /// <summary>
+        /// The server to connect to.
+        /// </summary>
+        string MultiplayerHost { get; }
+
+        /// <summary>
+        /// Establishes a connection with the server and starts listening for messages.
+        /// </summary>
+        void Connect() => ConnectAsync().GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Establishes a connection with the server and starts listening for messages.
+        /// </summary>
+        Task ConnectAsync();
+
+        /// <summary>
+        /// Sends a message to the server.
+        /// </summary>
+        /// <param name="scope">The scope of the message.</param>
+        /// <param name="type">The type of the message.</param>
+        /// <param name="data">An array of data to be sent.</param>
+        void Send(ConnectionScope scope, MessageType type, params object[] data) => Send(new Message(scope, type, data));
+
+        /// <summary>
+        /// Sends a message to the server.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        void Send(Message message) => SendAsync(message).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Sends a message to the server as an asynchronous operation.
+        /// </summary>
+        /// <param name="scope">The scope of the message.</param>
+        /// <param name="type">The type of the message.</param>
+        /// <param name="data">An array of data to be sent.</param>
+        Task SendAsync(ConnectionScope scope, MessageType type, params object[] data) => SendAsync(new Message(scope, type, data));
+
+        /// <summary>
+        /// Sends a message to the server as an asynchronous operation.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        public Task SendAsync(Message message);
+
+        /// <summary>
+        /// Creates a connection with the lobby.
+        /// </summary>
+        public IConnection CreateLobbyConnection();
+
+        /// <summary>
+        /// Creates a connection with the specified world.
+        /// </summary>
+        /// <param name="worldId">The world id to connect to.</param>
+        public IConnection CreateWorldConnection(string worldId);
+    }
+}

--- a/EEUniverse.Library/IConnection.cs
+++ b/EEUniverse.Library/IConnection.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace EEUniverse.Library
+{
+	public interface IConnection
+    {
+        event EventHandler<Message> OnMessage;
+
+        /// <summary>
+        /// Sends a message to the server.
+        /// </summary>
+        /// <param name="type">The type of the message.</param>
+        /// <param name="data">An array of data to be sent.</param>
+        void Send(MessageType type, params object[] data) => SendAsync(type, data).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Sends a message to the server.
+        /// </summary>
+        /// <param name="message">The message to be sent.</param>
+        void Send(Message message) => SendAsync(message).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Sends an asynchronous message to the server.
+        /// </summary>
+        /// <param name="type">The type of the message.</param>
+        /// <param name="data">An array of data to be sent.</param>
+        Task SendAsync(MessageType type, params object[] data);
+
+        /// <summary>
+        /// Sends an asynchronous message to the server.
+        /// </summary>
+        /// <param name="message">The message to be sent.</param>
+        Task SendAsync(Message message);
+    }
+}

--- a/EEUniverse.Library/Message.cs
+++ b/EEUniverse.Library/Message.cs
@@ -8,7 +8,7 @@ namespace EEUniverse.Library
     /// <summary>
     /// Represents an Everybody Edits Universe™ message.
     /// </summary>
-    public class Message : IEnumerable
+    public class Message : IEnumerable<object>
     {
         /// <summary>
         /// Represents the scope this message was received in.
@@ -55,6 +55,7 @@ namespace EEUniverse.Library
         /// </summary>
         public IEnumerator GetEnumerator() => _data.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator<object> IEnumerable<object>.GetEnumerator() => ((IEnumerable<object>)_data).GetEnumerator();
 
         /// <summary>
         /// Sets data at the given index to the given object.
@@ -66,7 +67,7 @@ namespace EEUniverse.Library
         /// <summary>
         /// Adds one or more objects to the existing message data.
         /// </summary>
-        /// <param name="value">The object to add.</param>
+        /// <param name="values">The objects to add.</param>
         public void Add(params object[] values) => _data.AddRange(values);
 
         /// <summary>


### PR DESCRIPTION
Allows for easier mocking and injection. The interfaces also implement some of the "boring" methods (e.g. Send -> SendAsync), as well as primarily contain the documentation so the Connection/Client can be easier read.

Other minor touches:
- Client exposes "Socket" so users can call the methods they'd like on it
- Client implements IDisposableAsync
- Message implements IEnumerable<object>

Noticeable changes:
- IClient and IConnection do not expose "SendRawAsync" or "SendRaw". This is considered implementation specific, and left up to the implementors.
- Client exposes more of its implementation details so the consumer can control what they'd like to do.